### PR TITLE
fix: peerDependency react v17

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
   },
   "peerDependencies": {
     "@antv/l7": "^2.2.37",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1"
   },
   "devDependencies": {
     "@antv/l7": "^2.2.37",


### PR DESCRIPTION
Fix package installation with node 14+ and npm 7+

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: ant-design-pro@5.0.0
npm ERR! Found: react@17.0.2
npm ERR! node_modules/react
npm ERR!   react@"^17.0.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.8.6" from @antv/l7-react@2.3.4
npm ERR! node_modules/@antv/l7-react
npm ERR!   @antv/l7-react@"^2.3.4" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /home/bvadell/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/bvadell/.npm/_logs/2021-10-18T07_25_10_124Z-debug.log
```